### PR TITLE
[Proposal] Move swapfile config into rc.local

### DIFF
--- a/fpm-package-builder/ethereumonarm-armbian-extras/Makefile
+++ b/fpm-package-builder/ethereumonarm-armbian-extras/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG_NAME := ethereumonarm-armbian-extras
 PKG_DESCRIPTION := "Armbian script to config zram, ramlog, and tmpdir for Ethereum on ARM images"
 
-PKG_VERSION := 1.2.0
+PKG_VERSION := 2.0.0
 PKG_RELEASE := 0
 
 PKG_MAINTAINER := "Fernando Collado <fcollado@ethereumonarm.com>"

--- a/fpm-package-builder/ethereumonarm-armbian-extras/extras/ethereumonarm-armbian-extras.postinst
+++ b/fpm-package-builder/ethereumonarm-armbian-extras/extras/ethereumonarm-armbian-extras.postinst
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -e
 
-# Set swapfile Defaults using dphys-swapfile
-
-sed -i 's/#CONF_SWAPFILE=\/var\/swap/CONF_SWAPFILE=\/home\/ethereum\/swapfile/' /etc/dphys-swapfile
-sed -i 's/#CONF_SWAPSIZE=/CONF_SWAPSIZE=8192/' /etc/dphys-swapfile
-sed -i 's/#CONF_MAXSWAP=2048/CONF_MAXSWAP=8192/' /etc/dphys-swapfile
-systemctl enable dphys-swapfile
-
 # Automatically added by dh_installsystemd/13.2ubuntu1
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
 	# This will only remove masks created by d-s-h on package removal.

--- a/image-creation-tool/ubuntu-rescue/sources/etc/rc.local
+++ b/image-creation-tool/ubuntu-rescue/sources/etc/rc.local
@@ -80,6 +80,12 @@ if [ ! -f $FLAG ]; then
   echo "vm.dirty_background_ratio=1" >> /etc/sysctl.conf
   echo "vm.dirty_ratio=50" >> /etc/sysctl.conf
 
+  # Set swapfile Defaults using dphys-swapfile
+  sed -i 's/#CONF_SWAPFILE=\/var\/swap/CONF_SWAPFILE=\/home\/ethereum\/swapfile/' /etc/dphys-swapfile
+  sed -i 's/#CONF_SWAPSIZE=/CONF_SWAPSIZE=8192/' /etc/dphys-swapfile
+  sed -i 's/#CONF_MAXSWAP=2048/CONF_MAXSWAP=8192/' /etc/dphys-swapfile
+  systemctl enable dphys-swapfile
+
   # Ethereum software installation
   # Add APT EthRaspbian repository
   sleep 25

--- a/image-creation-tool/ubuntu/sources/etc/rc.local
+++ b/image-creation-tool/ubuntu/sources/etc/rc.local
@@ -80,6 +80,12 @@ if [ ! -f $FLAG ]; then
   echo "vm.dirty_background_ratio=1" >> /etc/sysctl.conf
   echo "vm.dirty_ratio=50" >> /etc/sysctl.conf
 
+  # Set swapfile Defaults using dphys-swapfile
+  sed -i 's/#CONF_SWAPFILE=\/var\/swap/CONF_SWAPFILE=\/home\/ethereum\/swapfile/' /etc/dphys-swapfile
+  sed -i 's/#CONF_SWAPSIZE=/CONF_SWAPSIZE=8192/' /etc/dphys-swapfile
+  sed -i 's/#CONF_MAXSWAP=2048/CONF_MAXSWAP=8192/' /etc/dphys-swapfile
+  systemctl enable dphys-swapfile
+
   # Ethereum software installation
   # Add APT EthRaspbian repository
   sleep 25


### PR DESCRIPTION
I would like to re-use the ethereumonarm-armbian-extras package. I did an audit of the package, and found that it generally does a good job of cleaning up after itself when you purge it with apt. 

The only exception is the swapfile config. This gets setup automatically in the postinst script, but never gets cleaned up. Additionally, the parameters used in that config are not configurable. In my case, that's a problem because I prefer to mount my SSD somewhere outside of $HOME, which means I would also put my swapfile outside of $HOME

I propose that we move this logic out of this package and into the rc.local scripts so that this package is easier to re-use. I've also bumped the package version to 2.0.0, since this is technically a breaking change within the package (in case you are adhering to semantic versioning)