### PR TITLE
Add configuration files to enable Erigon on Gnosis Chain

### DIFF
--- a/docs/user-guide/running-l2-clients.rst
+++ b/docs/user-guide/running-l2-clients.rst
@@ -175,11 +175,11 @@ Gnosis Chain, formerly xDai, is an Ethereum-compatible sidechain that serves as 
 scaling solution and provides a more efficient environment for Gnosis applications and other 
 Ethereum-based projects.
 
-:guilabel:`Gnosis` is already implemented in wome Layer 1 clients so we can use the same client binaries but 
+:guilabel:`Gnosis` is already implemented in some Layer 1 clients so we can use the same client binaries but 
 with different configurations.
 
 Like the Layer 1 clients you need to run a Consensus Layer node and an Execution Layer client. Layer 1 
-clients guilabel:`Nethermind` and guilabel:`Lighthouse` are already configured to run a Gnosis chain so we just need to start 
+clients :guilabel:`Nethermind`, :guilabel:`Erigon` and :guilabel:`Lighthouse` are already configured to run a Gnosis chain node so we just need to start 
 the Systemd services:
 
 .. prompt:: bash $
@@ -187,12 +187,20 @@ the Systemd services:
   sudo systemctl start lighthouse-beacon-gnosis
   sudo journalctl -u lighthouse-beacon-gnosis -f
 
-And
+For the execution client one can either use :guilabel:`Nethermind` or :guilabel:`Erigon`. 
+To use :guilabel:`Nethermind`:
 
 .. prompt:: bash $
 
   sudo systemctl start nethermind-gnosis
   sudo journalctl -u nethermind-gnosis -f
+
+To use :guilabel:`Erigon` instead of :guilabel:`Nethermind`:
+
+.. prompt:: bash $
+
+  sudo systemctl start erigon-gnosis
+  sudo journalctl -u erigon-gnosis -f
 
 Remember to forward the default ports: `9000` and `30303`
 

--- a/fpm-package-builder/l1-clients/execution-layer/erigon/extras/erigon-gnosis.service
+++ b/fpm-package-builder/l1-clients/execution-layer/erigon/extras/erigon-gnosis.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Ethereum Erigon client daemon
+After=network.target
+
+[Service]
+Environment="GODEBUG=netdns=go"
+EnvironmentFile=/etc/ethereum/erigon-gnosis.conf
+ExecStart=/usr/bin/erigon $ARGS
+Restart=always
+User=ethereum
+
+[Install]
+WantedBy=multi-user.target
+

--- a/fpm-package-builder/l1-clients/execution-layer/erigon/sources/etc/ethereum/erigon-gnosis.conf
+++ b/fpm-package-builder/l1-clients/execution-layer/erigon/sources/etc/ethereum/erigon-gnosis.conf
@@ -1,0 +1,1 @@
+ARGS="--chain=gnosis --prune=htcr --authrpc.jwtsecret=/etc/ethereum/jwtsecret --datadir /home/ethereum/.erigon --http --http.addr 0.0.0.0 --metrics --metrics.port 5050 --ws --private.api.addr localhost:8092"


### PR DESCRIPTION
Erigon supports Gnosis chain as an execution client. I run erigon-gnosis with these config and service files for around 9 months now on an Orange Pi 5 Plus. It took 2-3 weeks to sync, but did it without any issues. It currently (July 2024) takes about 1 TB of space on the ssd.

To use it one has to start `sudo systemctl start erigon-gnosis`

I also extended the docs to include that erigon can now be used to run a gnosis chain node and fixed some typos and formatting issues along the way.

The '--prune=htcr' settings are the ones suggested in the official gnosis chain docs: https://docs.gnosischain.com/node/manual/execution/erigon, that is why I have chosen to use them here as well.